### PR TITLE
Fix #180 Allow User to Leave Organization

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
 
   resources :organizations, except: [:destroy] do
     post :join,  to: 'memberships#join',       on: :member
-    put  :leave, to: 'memberships#deactivate', on: :member
+    post  :leave, to: 'memberships#deactivate', on: :member
     get  :admin, to: 'memberships#admin',      on: :member
   end
 


### PR DESCRIPTION
Fixes the route to use the POST verb so that the organization leaving function works.